### PR TITLE
Bootstrap and import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk --no-cache add monero && \
-    rm /usr/bin/monero-blockchain-import /usr/bin/monero-blockchain-export /usr/bin/monero-wallet-rpc /usr/bin/monero-wallet-cli
+    rm /usr/bin/monero-blockchain-export /usr/bin/monero-wallet-rpc /usr/bin/monero-wallet-cli
 
 EXPOSE 18080 18081
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:edge
 
+ADD bootstrap.sh /root/bootstrap.sh
+
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk --no-cache add monero && \
-    rm /usr/bin/monero-blockchain-export /usr/bin/monero-wallet-rpc /usr/bin/monero-wallet-cli
+    rm /usr/bin/monero-blockchain-export /usr/bin/monero-wallet-rpc /usr/bin/monero-wallet-cli && \
+    chmod +x /root/bootstrap.sh
 
 EXPOSE 18080 18081
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ Example bootstrap from raw blockchain file:
 docker run -it -v /path/to/host/directory:/root/.bitmonero --entrypoint /root/bootstrap.sh mazhead/alpine_monerod:latest
 ```
 **Please note that this bootstrap uses a raw blockchain file and will not use the verify option. So if you do not trust the source use the sync over network above**
+
+You can run the bootstrap version multiple times as it happens that wget may fail during download. The blochain.raw should have >29GB in final.

--- a/README.md
+++ b/README.md
@@ -3,14 +3,22 @@
 Uses alpine edge with testing repository. Use with caution.
 
 Additionally these binaries are removed during image build to reduce size:
+
 ```
-/usr/bin/monero-blockchain-import
 /usr/bin/monero-blockchain-export
 /usr/bin/monero-wallet-rpc
 /usr/bin/monero-wallet-cli
 ```
 
-Example run:
+
+Example run with sync over network (will take long time if starting for the first time):
 ```
 docker run -itd -p 18080:18080 -p 18081:18081 -v /path/to/host/directory:/root/.bitmonero --restart unless-stopped --name monero_node mazhead/alpine_monerod:latest
 ```
+
+
+Example bootstrap from raw blockchain file:
+```
+docker run -it -v /path/to/host/directory:/root/.bitmonero --entrypoint /root/bootstrap.sh mazhead/alpine_monerod:latest
+```
+**Please note that this bootstrap uses a raw blockchain file and will not use the verify option. So if you do not trust the source use the sync over network above**

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# This is intended to bootstrap a monero node faster.
+# It will use official blockain.raw file and verify 0.
+# Sync via network if you do not trust the file or do not want to turn off verify 
+
+
+cd /root/.bitmonero || exit
+
+echo "################"
+echo "Downloading raw blockchain"
+echo "################"
+
+wget https://downloads.getmonero.org/blockchain.raw
+
+echo "################"
+echo "Starting import"
+echo "################"
+
+/usr/bin/monero-blockchain-import --verify 0 --input-file ./blockchain.raw
+
+rm /root/.bitmonero/blockchain.raw
+
+exit 0


### PR DESCRIPTION
Reverting the removal of import command as by default the network sync takes too long.
Adding bootstrap.sh to ease the setup of a monero node from scratch. 
Extending README to cover both situations.